### PR TITLE
add jaspDistributions to the DESCRIPTION file

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,7 +13,9 @@ Imports:
   ggplot2,
   jaspBase,
   jaspGraphs,
+  jaspDistributions,
   ggforce
 Remotes:
   jasp-stats/jaspBase,
-  jasp-stats/jaspGraphs
+  jasp-stats/jaspGraphs,
+  jasp-stats/jaspDistributions


### PR DESCRIPTION
@JTPetter you mentioned that you could not install the module if you added `jaspDistributions` to the `DESCRIPTION` file. Not sure what went wrong there, but for me this works... Perhaps you forgot to add it to the `Remotes` field?  In any case this should be the way to do it, well as long as we want to reuse the functionality here.