### PR TITLE
Force remove empty strings in po

### DIFF
--- a/po/QML-de.po
+++ b/po/QML-de.po
@@ -330,11 +330,6 @@ msgctxt "LSTcentralLimitTheorem|"
 msgid "All"
 msgstr "Alle"
 
-#: /home/runner/work/jaspLearnStats/jaspLearnStats/inst/qml/LSTcentralLimitTheorem.qml:211
-msgctxt "LSTcentralLimitTheorem|"
-msgid ""
-msgstr ""
-
 #: /home/runner/work/jaspLearnStats/jaspLearnStats/inst/qml/LSTcentralLimitTheorem.qml:223
 msgctxt "LSTcentralLimitTheorem|"
 msgid "From"
@@ -834,11 +829,6 @@ msgctxt "LSTsampleVariability|"
 msgid "All"
 msgstr "Alle"
 
-#: /home/runner/work/jaspLearnStats/jaspLearnStats/inst/qml/LSTsampleVariability.qml:275
-msgctxt "LSTsampleVariability|"
-msgid ""
-msgstr ""
-
 #: /home/runner/work/jaspLearnStats/jaspLearnStats/inst/qml/LSTsampleVariability.qml:287
 msgctxt "LSTsampleVariability|"
 msgid "From"
@@ -1056,11 +1046,6 @@ msgctxt "LSTstandardError|"
 msgid "All"
 msgstr "Alle"
 
-#: /home/runner/work/jaspLearnStats/jaspLearnStats/inst/qml/LSTstandardError.qml:211
-msgctxt "LSTstandardError|"
-msgid ""
-msgstr ""
-
 #: /home/runner/work/jaspLearnStats/jaspLearnStats/inst/qml/LSTstandardError.qml:223
 msgctxt "LSTstandardError|"
 msgid "From"
@@ -1228,20 +1213,10 @@ msgctxt "PValues|"
 msgid "Specify test statistic"
 msgstr "Teststatistik angeben"
 
-#: /home/runner/work/jaspLearnStats/jaspLearnStats/inst/qml/PValues.qml:100
-msgctxt "PValues|"
-msgid ""
-msgstr ""
-
 #: /home/runner/work/jaspLearnStats/jaspLearnStats/inst/qml/PValues.qml:111
 msgctxt "PValues|"
 msgid "Specify p-value"
 msgstr "p-Wert angeben"
-
-#: /home/runner/work/jaspLearnStats/jaspLearnStats/inst/qml/PValues.qml:117
-msgctxt "PValues|"
-msgid ""
-msgstr ""
 
 #: /home/runner/work/jaspLearnStats/jaspLearnStats/inst/qml/PValues.qml:131
 msgctxt "PValues|"

--- a/po/QML-es.po
+++ b/po/QML-es.po
@@ -324,11 +324,6 @@ msgctxt "LSTcentralLimitTheorem|"
 msgid "All"
 msgstr "Todo"
 
-#: /home/runner/work/jaspLearnStats/jaspLearnStats/inst/qml/LSTcentralLimitTheorem.qml:211
-msgctxt "LSTcentralLimitTheorem|"
-msgid ""
-msgstr "  "
-
 #: /home/runner/work/jaspLearnStats/jaspLearnStats/inst/qml/LSTcentralLimitTheorem.qml:223
 msgctxt "LSTcentralLimitTheorem|"
 msgid "From"
@@ -824,11 +819,6 @@ msgctxt "LSTsampleVariability|"
 msgid "All"
 msgstr "Todo"
 
-#: /home/runner/work/jaspLearnStats/jaspLearnStats/inst/qml/LSTsampleVariability.qml:275
-msgctxt "LSTsampleVariability|"
-msgid ""
-msgstr "  "
-
 #: /home/runner/work/jaspLearnStats/jaspLearnStats/inst/qml/LSTsampleVariability.qml:287
 msgctxt "LSTsampleVariability|"
 msgid "From"
@@ -1044,11 +1034,6 @@ msgctxt "LSTstandardError|"
 msgid "All"
 msgstr "Todo"
 
-#: /home/runner/work/jaspLearnStats/jaspLearnStats/inst/qml/LSTstandardError.qml:211
-msgctxt "LSTstandardError|"
-msgid ""
-msgstr "  "
-
 #: /home/runner/work/jaspLearnStats/jaspLearnStats/inst/qml/LSTstandardError.qml:223
 msgctxt "LSTstandardError|"
 msgid "From"
@@ -1216,20 +1201,10 @@ msgctxt "PValues|"
 msgid "Specify test statistic"
 msgstr "Especificar un estadístico de prueba"
 
-#: /home/runner/work/jaspLearnStats/jaspLearnStats/inst/qml/PValues.qml:100
-msgctxt "PValues|"
-msgid ""
-msgstr ""
-
 #: /home/runner/work/jaspLearnStats/jaspLearnStats/inst/qml/PValues.qml:111
 msgctxt "PValues|"
 msgid "Specify p-value"
 msgstr "Especificar el valor p"
-
-#: /home/runner/work/jaspLearnStats/jaspLearnStats/inst/qml/PValues.qml:117
-msgctxt "PValues|"
-msgid ""
-msgstr "  "
 
 #: /home/runner/work/jaspLearnStats/jaspLearnStats/inst/qml/PValues.qml:131
 msgctxt "PValues|"

--- a/po/QML-gl.po
+++ b/po/QML-gl.po
@@ -324,11 +324,6 @@ msgctxt "LSTcentralLimitTheorem|"
 msgid "All"
 msgstr "Todo"
 
-#: /home/runner/work/jaspLearnStats/jaspLearnStats/inst/qml/LSTcentralLimitTheorem.qml:211
-msgctxt "LSTcentralLimitTheorem|"
-msgid ""
-msgstr "  "
-
 #: /home/runner/work/jaspLearnStats/jaspLearnStats/inst/qml/LSTcentralLimitTheorem.qml:223
 msgctxt "LSTcentralLimitTheorem|"
 msgid "From"
@@ -824,11 +819,6 @@ msgctxt "LSTsampleVariability|"
 msgid "All"
 msgstr "Todo"
 
-#: /home/runner/work/jaspLearnStats/jaspLearnStats/inst/qml/LSTsampleVariability.qml:275
-msgctxt "LSTsampleVariability|"
-msgid ""
-msgstr "  "
-
 #: /home/runner/work/jaspLearnStats/jaspLearnStats/inst/qml/LSTsampleVariability.qml:287
 msgctxt "LSTsampleVariability|"
 msgid "From"
@@ -1044,11 +1034,6 @@ msgctxt "LSTstandardError|"
 msgid "All"
 msgstr "Todo"
 
-#: /home/runner/work/jaspLearnStats/jaspLearnStats/inst/qml/LSTstandardError.qml:211
-msgctxt "LSTstandardError|"
-msgid ""
-msgstr "  "
-
 #: /home/runner/work/jaspLearnStats/jaspLearnStats/inst/qml/LSTstandardError.qml:223
 msgctxt "LSTstandardError|"
 msgid "From"
@@ -1216,20 +1201,10 @@ msgctxt "PValues|"
 msgid "Specify test statistic"
 msgstr "Especificar un estatístico de proba"
 
-#: /home/runner/work/jaspLearnStats/jaspLearnStats/inst/qml/PValues.qml:100
-msgctxt "PValues|"
-msgid ""
-msgstr ""
-
 #: /home/runner/work/jaspLearnStats/jaspLearnStats/inst/qml/PValues.qml:111
 msgctxt "PValues|"
 msgid "Specify p-value"
 msgstr "Especificar o valor p"
-
-#: /home/runner/work/jaspLearnStats/jaspLearnStats/inst/qml/PValues.qml:117
-msgctxt "PValues|"
-msgid ""
-msgstr "  "
 
 #: /home/runner/work/jaspLearnStats/jaspLearnStats/inst/qml/PValues.qml:131
 msgctxt "PValues|"

--- a/po/QML-pl.po
+++ b/po/QML-pl.po
@@ -1309,28 +1309,3 @@ msgstr ""
 msgctxt "PValues|"
 msgid "Introductory text"
 msgstr ""
-
-#: /home/runner/work/jaspLearnStats/jaspLearnStats/inst/qml/LSTcentralLimitTheorem.qml:211
-msgctxt "LSTcentralLimitTheorem|"
-msgid ""
-msgstr ""
-
-#: /home/runner/work/jaspLearnStats/jaspLearnStats/inst/qml/LSTsampleVariability.qml:275
-msgctxt "LSTsampleVariability|"
-msgid ""
-msgstr ""
-
-#: /home/runner/work/jaspLearnStats/jaspLearnStats/inst/qml/LSTstandardError.qml:211
-msgctxt "LSTstandardError|"
-msgid ""
-msgstr ""
-
-#: /home/runner/work/jaspLearnStats/jaspLearnStats/inst/qml/PValues.qml:100
-msgctxt "PValues|"
-msgid ""
-msgstr ""
-
-#: /home/runner/work/jaspLearnStats/jaspLearnStats/inst/qml/PValues.qml:117
-msgctxt "PValues|"
-msgid ""
-msgstr ""

--- a/po/QML-tr.po
+++ b/po/QML-tr.po
@@ -1308,28 +1308,3 @@ msgstr "Seçenekler"
 msgctxt "PValues|"
 msgid "Introductory text"
 msgstr "Tanıtım Metni"
-
-#: /home/runner/work/jaspLearnStats/jaspLearnStats/inst/qml/LSTcentralLimitTheorem.qml:211
-msgctxt "LSTcentralLimitTheorem|"
-msgid ""
-msgstr ""
-
-#: /home/runner/work/jaspLearnStats/jaspLearnStats/inst/qml/LSTsampleVariability.qml:275
-msgctxt "LSTsampleVariability|"
-msgid ""
-msgstr ""
-
-#: /home/runner/work/jaspLearnStats/jaspLearnStats/inst/qml/LSTstandardError.qml:211
-msgctxt "LSTstandardError|"
-msgid ""
-msgstr ""
-
-#: /home/runner/work/jaspLearnStats/jaspLearnStats/inst/qml/PValues.qml:100
-msgctxt "PValues|"
-msgid ""
-msgstr ""
-
-#: /home/runner/work/jaspLearnStats/jaspLearnStats/inst/qml/PValues.qml:117
-msgctxt "PValues|"
-msgid ""
-msgstr ""

--- a/po/QML-zh_Hans.po
+++ b/po/QML-zh_Hans.po
@@ -324,11 +324,6 @@ msgctxt "LSTcentralLimitTheorem|"
 msgid "All"
 msgstr ""
 
-#: /home/runner/work/jaspLearnStats/jaspLearnStats/inst/qml/LSTcentralLimitTheorem.qml:211
-msgctxt "LSTcentralLimitTheorem|"
-msgid ""
-msgstr ""
-
 #: /home/runner/work/jaspLearnStats/jaspLearnStats/inst/qml/LSTcentralLimitTheorem.qml:223
 msgctxt "LSTcentralLimitTheorem|"
 msgid "From"
@@ -824,11 +819,6 @@ msgctxt "LSTsampleVariability|"
 msgid "All"
 msgstr ""
 
-#: /home/runner/work/jaspLearnStats/jaspLearnStats/inst/qml/LSTsampleVariability.qml:275
-msgctxt "LSTsampleVariability|"
-msgid ""
-msgstr ""
-
 #: /home/runner/work/jaspLearnStats/jaspLearnStats/inst/qml/LSTsampleVariability.qml:287
 msgctxt "LSTsampleVariability|"
 msgid "From"
@@ -1044,11 +1034,6 @@ msgctxt "LSTstandardError|"
 msgid "All"
 msgstr ""
 
-#: /home/runner/work/jaspLearnStats/jaspLearnStats/inst/qml/LSTstandardError.qml:211
-msgctxt "LSTstandardError|"
-msgid ""
-msgstr ""
-
 #: /home/runner/work/jaspLearnStats/jaspLearnStats/inst/qml/LSTstandardError.qml:223
 msgctxt "LSTstandardError|"
 msgid "From"
@@ -1216,19 +1201,9 @@ msgctxt "PValues|"
 msgid "Specify test statistic"
 msgstr ""
 
-#: /home/runner/work/jaspLearnStats/jaspLearnStats/inst/qml/PValues.qml:100
-msgctxt "PValues|"
-msgid ""
-msgstr ""
-
 #: /home/runner/work/jaspLearnStats/jaspLearnStats/inst/qml/PValues.qml:111
 msgctxt "PValues|"
 msgid "Specify p-value"
-msgstr ""
-
-#: /home/runner/work/jaspLearnStats/jaspLearnStats/inst/qml/PValues.qml:117
-msgctxt "PValues|"
-msgid ""
 msgstr ""
 
 #: /home/runner/work/jaspLearnStats/jaspLearnStats/inst/qml/PValues.qml:131


### PR DESCRIPTION
Empty strings damaged .po file head so Weblate and Qt linguist have some complain.

Although I removed empty qsTr() from QML in last PR. but the po file does not automatically remove outdated empty strings as I reported bug in [Qt Linguist](https://bugreports.qt.io/browse/QTBUG-110936).So until the upstream fix or this [issue ](https://github.com/jasp-stats/INTERNAL-jasp/issues/2219) is done, we have to manually remove the empty strings manually from the po files.