### PR TITLE
Align many samples display

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,6 +15,7 @@ Imports:
   jaspGraphs,
   jaspDistributions,
   jaspDescriptives,
+  jaspTTests,
   ggforce,
   tidyr,
   igraph
@@ -22,4 +23,5 @@ Remotes:
   jasp-stats/jaspBase,
   jasp-stats/jaspGraphs,
   jasp-stats/jaspDistributions,
-  jasp-stats/jaspDescriptives
+  jasp-stats/jaspDescriptives,
+  jasp-stats/jaspTTests

--- a/R/LSTconfidenceIntervals.R
+++ b/R/LSTconfidenceIntervals.R
@@ -189,9 +189,6 @@ LSTconfidenceIntervals <- function(jaspResults, dataset = NULL, options) {
   if (!is.null(jaspContainer[["containerRainCloudPlots"]]) || !options$dataPlot)
     return()
   
-  rainData <- data.frame(y = unlist(jaspContainer[["simulatedDatasets"]][["object"]]), 
-                         group = rep(seq_len(options$nReps), each = options$n))
-  
   jaspContainer[["containerRainCloudPlots"]] <- createJaspContainer(gettext("Data plots"), 
                                                                     dependencies = c("dataPlotShowN", "dataPlot"))
   
@@ -204,7 +201,7 @@ LSTconfidenceIntervals <- function(jaspResults, dataset = NULL, options) {
   matrixPlot <- createJaspPlot(title = gettext("Samples"), width = 960/(3/nCols), 
                                height = 800/(3/nRows))
   
-  plotList <- matrix(list(), nRows, nCols)
+  plotList <- list()
   
   if (addDots) {
     loopingVector <- c(1, 2, (options$dataPlotShowN-6):options$dataPlotShowN)
@@ -222,14 +219,16 @@ LSTconfidenceIntervals <- function(jaspResults, dataset = NULL, options) {
                           size = 60)
     } else {
       
-      thisRainData <- data.frame(y = unlist(jaspContainer[["simulatedDatasets"]][["object"]][[i]]), 
+      thisRainData <- data.frame(y = rainData[[i]], 
                                  group = rep(1, options$n))  
       
-      plotList[[listCounter]] <- try(jaspTTests::.descriptivesPlotsRainCloudFill(thisRainData, "y", "group", 
-                                                                                 yLabel = gettext("Dependent"), 
+      plotList[[listCounter]] <- try(jaspTTests::.descriptivesPlotsRainCloudFill(thisRainData, "y", "group",
+                                                                                 yLabel = gettext("Dependent"),
                                                                                  xLabel = gettextf("Repetition %d", i),
                                                                                  testValue = options$mu,
                                                                                  addLines = FALSE, horiz = FALSE))
+      
+      
       if(isTryError(plotList[[listCounter]]))
         matrixPlot$setError(.extractErrorMessage(plotList[[listCounter]]))
       
@@ -279,7 +278,7 @@ LSTconfidenceIntervals <- function(jaspResults, dataset = NULL, options) {
     ggplot2::xlab(gettext("Number of Replications")) +
     ggplot2::ylab(gettext("p(Coverage)")) +
     ggplot2::coord_cartesian(xlim = c(0, options$nReps), ylim = myYlim) + 
-    ggplot2::geom_polygon(ggplot2::aes(x = c(1:options$nReps,options$nReps:1), y = c(y.upper, rev(y.lower))),
+    ggplot2::geom_polygon(ggplot2::aes(x = c(1:options$nReps,options$nReps:1), y = c(yUpper, rev(yLower))),
                           fill = "lightsteelblue") +  # CI
     ggplot2::geom_line(color = "darkred", ggplot2::aes(x = 1:options$nReps, 
                                                        y = rep(options$confidenceIntervalInterval, options$nReps))) +  # confidence level

--- a/R/LSTconfidenceIntervals.R
+++ b/R/LSTconfidenceIntervals.R
@@ -122,6 +122,7 @@ LSTconfidenceIntervals <- function(jaspResults, dataset = NULL, options) {
   
   meanCI <- jaspContainer[["computedConfidenceIntervals"]][["object"]]
   meanCI[["successfulCI"]] <- ifelse(meanCI[["successfulCI"]], "Yes", "No")
+  meanCI <- meanCI[1:options$dataPlotShowN,]  # Show data only for CIs that are also plotted
   
   treeTable$showSpecifiedColumnsOnly <- TRUE
   treeTable$setData(meanCI)

--- a/R/LSTdecisionTree.R
+++ b/R/LSTdecisionTree.R
@@ -78,7 +78,6 @@ LSTdecisionTree <- function(jaspResults, dataset = NULL, options) {
   nodesDf <- subset(nodesDf, !grepl("NULL", nodesDf$label))
   decisionDf <- subset(decisionDf, !(grepl("NULL", decisionDf$from) | grepl("NULL", decisionDf$to)))
   
-  
   # add edges that skip rows
   extraEdges <- data.frame(from = c("Continuous3", "Continuous4", "Categorical3", "Categorical3", "Categorical3",
                                     "Both", "Continuous5", "Categorical4", "Continuous6", "Categorical5", "Both2",

--- a/R/LSTdecisionTree.R
+++ b/R/LSTdecisionTree.R
@@ -77,7 +77,7 @@ LSTdecisionTree <- function(jaspResults, dataset = NULL, options) {
   #remove NULL nodes from edgesDf and decision Df
   nodesDf <- subset(nodesDf, !grepl("NULL", nodesDf$label))
   decisionDf <- subset(decisionDf, !(grepl("NULL", decisionDf$from) | grepl("NULL", decisionDf$to)))
-
+  
   
   # add edges that skip rows
   extraEdges <- data.frame(from = c("Continuous3", "Continuous4", "Categorical3", "Categorical3", "Categorical3",

--- a/R/LSTdecisionTree.R
+++ b/R/LSTdecisionTree.R
@@ -74,6 +74,20 @@ LSTdecisionTree <- function(jaspResults, dataset = NULL, options) {
                                   "Different4", "Logistic regression", "Different5", "Different6", "MANOVA", "Factorial MANOVA", "MANCOVA"))
   decisionDf <- rbind(decisionDf, extraEdges)
   
+  #remove NULL nodes from edgesDf and decision Df
+  nodesDf <- subset(nodesDf, !grepl("NULL", nodesDf$label))
+  decisionDf <- subset(decisionDf, !(grepl("NULL", decisionDf$from) | grepl("NULL", decisionDf$to)))
+
+  
+  # add edges that skip rows
+  extraEdges <- data.frame(from = c("Continuous3", "Continuous4", "Categorical3", "Categorical3", "Categorical3",
+                                    "Both", "Continuous5", "Categorical4", "Continuous6", "Categorical5", "Both2",
+                                    "Categorical6", "Categorical7", "Both3"),
+                           to = c("Pearson correlation \n or regression", "Multiple regression", "Same3", "Different3",
+                                  "Both4", "Multiple regression\n/ANCOVA", "Logistic regression or \n biserial/point biserial \n correlation",
+                                  "Different4", "Logistic regression", "Different5", "Different6", "MANOVA", "Factorial MANOVA", "MANCOVA"))
+  decisionDf <- rbind(decisionDf, extraEdges)
+  
   # data frame for edges
   edgesDf <- cbind(decisionDf, "id" = seq_len(nrow(decisionDf))) 
   edgesDf <- tidyr::pivot_longer(edgesDf, cols = c("from", "to"),

--- a/R/LSTdescriptives.R
+++ b/R/LSTdescriptives.R
@@ -26,9 +26,14 @@ LSTdescriptives <- function(jaspResults, dataset, options, state = NULL) {
   #checking whether data is discrete or continuous, whereas only integers are treated as discrete
   discrete <- ifelse(all(data$x == as.integer(data$x)), TRUE, FALSE)
   
+  centralOrSpread <- switch(options[["LSdescStatistics"]],
+                            "LSdescMean" = "ct", "LSdescMedian" = "ct", "LSdescMode" = "ct", "LSdescMMM" = "ct",
+                            "LSdescRange" = "spread", "LSdescQR" = "spread", "LSdescSD" = "spread",
+                            "none" = "none")
   
-  if (options[["LSdescCentralOrSpread"]] == "LSdescCentralTendency") {
-    if (options[["LSdescExplanationC"]])
+  
+  if (centralOrSpread == "ct" || centralOrSpread == "none") {
+    if (options[["LSdescExplanation"]])
       .descExplanationCT(jaspResults, options, colors)
     if (options[["LSdescHistBar"]])
       .lstDescCreateHistogramOrBarplot(jaspResults, options, data, ready, discrete, stats = "ct", colors)
@@ -36,8 +41,8 @@ LSTdescriptives <- function(jaspResults, dataset, options, state = NULL) {
       .lstDescCreateDotplot(jaspResults, options, data, ready, discrete, stats = "ct", colors)
   }
   
-  if (options[["LSdescCentralOrSpread"]] == "LSdescSpread") {
-    if (options[["LSdescExplanationS"]])
+  if (centralOrSpread == "spread") {
+    if (options[["LSdescExplanation"]])
       .descExplanationS(jaspResults, options, colors)
     if (options[["LSdescHistBar"]])
       .lstDescCreateHistogramOrBarplot(jaspResults, options, data, ready, discrete, stats = "spread", colors)
@@ -50,20 +55,19 @@ LSTdescriptives <- function(jaspResults, dataset, options, state = NULL) {
 .descExplanationS <- function(jaspResults, options, colors) {
   jaspResults[["descExplanationS"]] <- createJaspContainer(gettext("Explanation"))
   jaspResults[["descExplanationS"]]$position <- 1
-  jaspResults[["descExplanationS"]]$dependOn(options = c("LSdescCentralOrSpread",
-                                                         "LSdescS", 
-                                                         "LSdescExplanationS"))
+  jaspResults[["descExplanationS"]]$dependOn(options = c("LSdescStatistics",
+                                                         "LSdescExplanation"))
   
   set.seed(123)
   data <- data.frame(index = 1:21, x = rnorm(21, 10, 2.5))
   
   plot1 <- createJaspPlot(title = gettext("Visual Explanation"), width = 700, height = 700)
   
-  if (options[["LSdescS"]] == "LSdescRange") {
+  if (options[["LSdescStatistics"]] == "LSdescRange") {
     plot1$plotObject <- .visualExplanationRange(data, colors)
-  } else if (options[["LSdescS"]] == "LSdescQR") {
+  } else if (options[["LSdescStatistics"]] == "LSdescQR") {
     plot1$plotObject <- .visualExplanationQuartiles(data, colors)
-  } else if (options[["LSdescS"]] == "LSdescSD") {
+  } else if (options[["LSdescStatistics"]] == "LSdescSD") {
     plot1$plotObject <- .visualExplanationStdDev(data, colors)$plot1
     plot2 <- createJaspPlot(title = gettext("Visual Explanation 2"), width = 700, height = 700)
     plot2$plotObject <- .visualExplanationStdDev(data, colors)$plot2
@@ -304,9 +308,8 @@ LSTdescriptives <- function(jaspResults, dataset, options, state = NULL) {
 .descExplanationCT <- function(jaspResults, options, colors) {
   jaspResults[["descExplanationCT"]] <- createJaspContainer(gettext("Explanation"))
   jaspResults[["descExplanationCT"]]$position <- 1
-  jaspResults[["descExplanationCT"]]$dependOn(options = c("LSdescCentralOrSpread",
-                                                          "LSdescCT",
-                                                          "LSdescExplanationC"))
+  jaspResults[["descExplanationCT"]]$dependOn(options = c("LSdescStatistics",
+                                                          "LSdescExplanation"))
   
   pdPlot <- createJaspPlot(title = gettext("Theoretical example distribution"), width = 700, height = 400)
   pdPlot$position <- 1
@@ -321,17 +324,17 @@ LSTdescriptives <- function(jaspResults, dataset, options, state = NULL) {
   
   pdPlotObject <- .plotCTexampleDistribution(data)
   
-  allCTs <- options[["LSdescCT"]] == "LSdescMMM"
+  allCTs <- options[["LSdescStatistics"]] == "LSdescMMM"
   
-  if (options[["LSdescCT"]] == "LSdescMedian" | allCTs) {
+  if (options[["LSdescStatistics"]] == "LSdescMedian" | allCTs) {
     pdPlotObject <- .visualExplanationMedian(pdPlotObject, data, options, colors)
     text <- "Text for Median:  Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
   }
-  if (options[["LSdescCT"]] == "LSdescMode" | allCTs) {
+  if (options[["LSdescStatistics"]] == "LSdescMode" | allCTs) {
     pdPlotObject <- .visualExplanationMode(pdPlotObject, data, options, colors)
     text <- "Text for Mode:  Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
   }
-  if (options[["LSdescCT"]] == "LSdescMean" | allCTs) {
+  if (options[["LSdescStatistics"]] == "LSdescMean" | allCTs) {
     pdPlotObject <- .visualExplanationMean(pdPlotObject, data, options, colors)
     text <- "Text for Mean : Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
   }
@@ -386,8 +389,8 @@ LSTdescriptives <- function(jaspResults, dataset, options, state = NULL) {
   medianLineHeight <- plotData$y[.indexOfNearestValue(median, plotData$x)]
   medianLineData <- data.frame(x = c(rep(median, 2)), y = c(0, medianLineHeight))
   fiftyPercentLabels <- data.frame(x = c(median + .85, median - .85), y = rep(.1, 2), label = rep("50%", 2))
-  labelXPos <- ifelse(options[["LSdescCT"]] == "LSdescMMM", 4, median)
-  labelYPos <- ifelse(options[["LSdescCT"]] == "LSdescMMM", max(yLimits) * .85, max(yLimits) * .55)
+  labelXPos <- ifelse(options[["LSdescStatistics"]] == "LSdescMMM", 4, median)
+  labelYPos <- ifelse(options[["LSdescStatistics"]] == "LSdescMMM", max(yLimits) * .85, max(yLimits) * .55)
   
   plotObject <- plotObject +
     ggplot2::geom_ribbon(mapping = ggplot2::aes(ymin = 0, ymax = y), data = subset(plotData, plotData$x > median),
@@ -412,8 +415,8 @@ LSTdescriptives <- function(jaspResults, dataset, options, state = NULL) {
   
   modeVLineData <- data.frame(x = c(rep(mode, 2)), y = c(0, max(plotData$y)))
   modeHLineData <- data.frame(x = c(mode - .7, mode + .7), y = rep(max(plotData$y) + 0.003, 2))
-  labelXPos <- ifelse(options[["LSdescCT"]] == "LSdescMMM", 4, mode)
-  labelYPos <- ifelse(options[["LSdescCT"]] == "LSdescMMM", max(yLimits) * .75, max(yLimits) * .45)
+  labelXPos <- ifelse(options[["LSdescStatistics"]] == "LSdescMMM", 4, mode)
+  labelYPos <- ifelse(options[["LSdescStatistics"]] == "LSdescMMM", max(yLimits) * .75, max(yLimits) * .45)
   plotObject <- plotObject +
     ggplot2::geom_path(mapping = ggplot2::aes(x = x, y = y), data = modeVLineData, size = 1, color = colors[2]) +
     ggplot2::geom_path(mapping = ggplot2::aes(x = x, y = y), data = modeHLineData, size = 1, color = colors[2]) +
@@ -441,8 +444,8 @@ LSTdescriptives <- function(jaspResults, dataset, options, state = NULL) {
                                  y = seq(-.04, .02, length.out = 100))
   balanceLineData3 <- data.frame(x = balanceLineData1$x * -1, y = balanceLineData1$y)
   balanceLineData4 <- data.frame(x = balanceLineData2$x * -1, y = balanceLineData2$y)
-  labelXPos <- ifelse(options[["LSdescCT"]] == "LSdescMMM", 4, mean)
-  labelYPos <- ifelse(options[["LSdescCT"]] == "LSdescMMM", max(yLimits) * .95, max(yLimits) * .2)
+  labelXPos <- ifelse(options[["LSdescStatistics"]] == "LSdescMMM", 4, mean)
+  labelYPos <- ifelse(options[["LSdescStatistics"]] == "LSdescMMM", max(yLimits) * .95, max(yLimits) * .2)
   plotObject <- plotObject + 
     ggplot2::geom_path(mapping = ggplot2::aes(x = x, y = y), data = meanLineData, size = 1, color = colors[3]) +
     ggplot2::geom_polygon(mapping = ggplot2::aes(x = x, y = y), data = triangleData, fill = colors[3]) +
@@ -510,7 +513,7 @@ LSTdescriptives <- function(jaspResults, dataset, options, state = NULL) {
 .drawSpreadVisualization <- function(jaspResults, options, data, plotObject, yMax, xLimits, xBreaks, labelSize, colors) {
   xLimitUpper <- max(xLimits)
   xBreakLimit <- max(xBreaks)
-  if (options[["LSdescS"]] == "LSdescRange") {
+  if (options[["LSdescStatistics"]] == "LSdescRange") {
     minX <- min(data$x)
     maxX <- max(data$x)
     range <- maxX - minX
@@ -526,7 +529,7 @@ LSTdescriptives <- function(jaspResults, dataset, options, state = NULL) {
       ggplot2::geom_path(mapping = ggplot2::aes(x = x, y = y), data = rangeLineData, size = 1, color = colors[4]) +
       ggplot2::geom_label(mapping = ggplot2::aes(x = x, y = y, label = label), data = labelData, size = labelSize, 
                           color = colors[2:4])
-  } else if (options[["LSdescS"]] == "LSdescQR") {
+  } else if (options[["LSdescStatistics"]] == "LSdescQR") {
     quartiles <- quantile(data$x, type = 2)
     iqr <- quartiles[4] - quartiles[2]
     maxX <- max(data$x)
@@ -547,7 +550,7 @@ LSTdescriptives <- function(jaspResults, dataset, options, state = NULL) {
       ggplot2::geom_path(mapping = ggplot2::aes(x = x, y = y), data = iqrLineData, color = colors[6], size = 1) +
       ggplot2::geom_label(mapping = ggplot2::aes(x = x, y = y, label = label), data = labelData,
                           color = colors[c(4, 1, 5, 6)], size = labelSize)
-  }else if (options[["LSdescS"]] == "LSdescSD") {
+  }else if (options[["LSdescStatistics"]] == "LSdescSD") {
     stdDev <- sd(data$x)
     meanPoint <- mean(data$x)
     meanLineData <- data.frame(x = rep(meanPoint, 2), y = c(0, yMax * .95))
@@ -616,7 +619,7 @@ LSTdescriptives <- function(jaspResults, dataset, options, state = NULL) {
   jaspResults[["descHistogramOrBarplot"]] <- createJaspContainer(gettext(title))
   p <- createJaspPlot(title = gettext(title), width = 800, height = 700)
   p$position <- 2
-  p$dependOn(options = c("LSdescCentralOrSpread",
+  p$dependOn(options = c("LSdescStatistics",
                          "lstDescDataType",
                          "lstDescSampleN",
                          "lstDescSampleSeed",
@@ -625,8 +628,8 @@ LSTdescriptives <- function(jaspResults, dataset, options, state = NULL) {
                          "LSdescContinuousDistributions",
                          "lstDescDataSequenceInput",
                          "selectedVariable",
-                         "LSdescCT",
-                         "LSdescS",
+                         "LSdescStatistics",
+                         "LSdescStatistics",
                          "LSdescHistBar",
                          "LSdescHistCountOrDens",
                          "LSdescHistBarRugs"))
@@ -679,7 +682,7 @@ LSTdescriptives <- function(jaspResults, dataset, options, state = NULL) {
   height <- 700 + (length(data$x) / 50) * 25
   dp <- createJaspPlot(title = gettext("Dotplot"), width = 800, height = height)
   dp$position <- 3
-  dp$dependOn(options = c("LSdescCentralOrSpread",
+  dp$dependOn(options = c("LSdescStatistics",
                           "lstDescDataType",
                           "lstDescSampleN",
                           "lstDescSampleSeed",
@@ -688,8 +691,8 @@ LSTdescriptives <- function(jaspResults, dataset, options, state = NULL) {
                           "LSdescContinuousDistributions",
                           "lstDescDataSequenceInput",
                           "selectedVariable",
-                          "LSdescCT",
-                          "LSdescS",
+                          "LSdescStatistics",
+                          "LSdescStatistics",
                           "LSdescDotPlot",
                           "LSdescDotPlotRugs"))
   errors <- .plotErrors(dp, data, options, stats)$errors
@@ -705,7 +708,7 @@ LSTdescriptives <- function(jaspResults, dataset, options, state = NULL) {
 .plotErrors <- function(plot, data, options, stats) {
   errors <- FALSE
   if (stats == "spread"){
-    if (options[["LSdescS"]] == "LSdescSD") {
+    if (options[["LSdescStatistics"]] == "LSdescSD") {
       if (sd(data$x) == 0 | is.na(sd(data$x))){
         plot$setError(gettext("No variance: All values are equal."))
         errors <- TRUE
@@ -719,7 +722,7 @@ LSTdescriptives <- function(jaspResults, dataset, options, state = NULL) {
 .drawMeanMedianOrModeLine <- function(jaspResults, options, data, plot, yMax, xMax, xBreaks, lines = TRUE, discrete, colors) {
   n <- length(data$x)
   labelSize <- .getLabelSize(n)
-  if (options[["LSdescCT"]] == "LSdescMode"| options[["LSdescCT"]] == "LSdescMMM") {
+  if (options[["LSdescStatistics"]] == "LSdescMode"|| options[["LSdescStatistics"]] == "LSdescMMM") {
     xPos <- median(xBreaks)
     modeLines <- lines
     noMode <- length(unique(data$x)) == length(data$x)
@@ -767,38 +770,38 @@ LSTdescriptives <- function(jaspResults, dataset, options, state = NULL) {
       }
       plot <- plot + ggplot2::geom_hline(yintercept = modeLineYPos, size = 1, color = colors[2]) 
     }
-    if (options[["LSdescCT"]] == "LSdescMode") {
+    if (options[["LSdescStatistics"]] == "LSdescMode") {
       plot <- plot + ggplot2::geom_label(data = modeLabelData, 
                                          mapping = ggplot2::aes(x = x, y = y, label = label), color = colors[2], size = labelSize)
-    } else if (options[["LSdescCT"]] == "LSdescMMM") {
+    } else if (options[["LSdescStatistics"]] == "LSdescMMM") {
       modeLabelData$x <- max(xBreaks) + (xMax - max(xBreaks)) / 2
       modeLabelData$y <- yMax * .55
       plot <- plot + ggplot2::geom_label(data = modeLabelData, 
                                          mapping = ggplot2::aes(x = x, y = y, label = label), color = colors[2], size = labelSize)
     }
   }
-  if (options[["LSdescCT"]] == "LSdescMean" | options[["LSdescCT"]] == "LSdescMMM") {
+  if (options[["LSdescStatistics"]] == "LSdescMean" || options[["LSdescStatistics"]] == "LSdescMMM") {
     mean <- mean(data$x)
     if (lines)
       plot <- plot + ggplot2::geom_path(mapping = ggplot2::aes(x = x, y = y),
                                         data = data.frame(x = rep(mean, 2), y = c(0, yMax)), size = 1, color = colors[3])
-    if (options[["LSdescCT"]] == "LSdescMean") {
+    if (options[["LSdescStatistics"]] == "LSdescMean") {
       plot <- plot + ggplot2::geom_label(data = data.frame(x = mean, y = yMax, label = gettextf("Mean = %.2f", mean)), 
                                          mapping = ggplot2::aes(x = x, y = y, label = label), color = colors[3], size = labelSize)
-    } else if (options[["LSdescCT"]] == "LSdescMMM") {
+    } else if (options[["LSdescStatistics"]] == "LSdescMMM") {
       plot <- plot + ggplot2::geom_label(data = data.frame(x = max(xBreaks) + (xMax - max(xBreaks)) / 2, y = yMax * .95, label = gettextf("Mean = %.2f", mean)), 
                                          mapping = ggplot2::aes(x = x, y = y, label = label), color = colors[3], size = labelSize)
     }
   }
-  if (options[["LSdescCT"]] == "LSdescMedian"| options[["LSdescCT"]] == "LSdescMMM") {
+  if (options[["LSdescStatistics"]] == "LSdescMedian" || options[["LSdescStatistics"]] == "LSdescMMM") {
     median <- median(data$x)
     if (lines)
       plot <- plot + ggplot2::geom_path(mapping = ggplot2::aes(x = x, y = y),
                                         data = data.frame(x = rep(median, 2), y = c(0, yMax)), size = 1, color = colors[1])
-    if (options[["LSdescCT"]] == "LSdescMedian") {
+    if (options[["LSdescStatistics"]] == "LSdescMedian") {
       plot <- plot +  ggplot2::geom_label(data = data.frame(x = median, y = yMax, label = gettextf("Median = %.2f", median)), 
                                           mapping = ggplot2::aes(x = x, y = y, label = label), color = colors[1], size = labelSize)
-    } else if (options[["LSdescCT"]] == "LSdescMMM") {
+    } else if (options[["LSdescStatistics"]] == "LSdescMMM") {
       plot <- plot + ggplot2::geom_label(data = data.frame(x = max(xBreaks) + (xMax - max(xBreaks)) / 2, y = yMax * .75, label = gettextf("Median = %.2f", median)), 
                                          mapping = ggplot2::aes(x = x, y = y, label = label), color = colors[1], size = labelSize)
     }
@@ -842,12 +845,12 @@ LSTdescriptives <- function(jaspResults, dataset, options, state = NULL) {
     jaspGraphs::themeJaspRaw()
   
   if (stats == "ct") {
-    allCTs <- options[["LSdescCT"]] == "LSdescMMM"
-    if (options[["LSdescCT"]] == "LSdescMedian" | allCTs) {
+    allCTs <- options[["LSdescStatistics"]] == "LSdescMMM"
+    if (options[["LSdescStatistics"]] == "LSdescMedian" || allCTs) {
       p <- .dotPlotVisualizeQuartiles(data, p, dotsize, labelSize, yLimits, xLimits, xBreaks, labels = !allCTs, labelText = gettext("Median"), quartile = 2,
                                       lines = !allCTs, color = colors[1])
     }
-    if (options[["LSdescCT"]] == "LSdescMean" | allCTs) {
+    if (options[["LSdescStatistics"]] == "LSdescMean" || allCTs) {
       mean <- mean(data$x)
       y0 <- dotWidth / 2
       circleData <- data.frame(x0 = mean, 
@@ -863,7 +866,7 @@ LSTdescriptives <- function(jaspResults, dataset, options, state = NULL) {
       p <- .drawMeanMedianOrModeLine(jaspResults, options, data, p, yMax = max(yLimits), xMax = max(xLimits), xBreaks,
                                      lines = FALSE, discrete = discrete, colors = colors)
     }
-    if (options[["LSdescCT"]] == "LSdescMode" | allCTs) {
+    if (options[["LSdescStatistics"]] == "LSdescMode" || allCTs) {
       if (length(unique(data$x)) != n) {
         modeTable <- table(data$x)
         mode <- as.numeric(names(modeTable[modeTable == max(modeTable)]))
@@ -879,9 +882,9 @@ LSTdescriptives <- function(jaspResults, dataset, options, state = NULL) {
                                      lines = FALSE, discrete = discrete, colors = colors)
     }
   } else if (stats == "spread") {
-    if (options[["LSdescS"]] == "LSdescRange") {
+    if (options[["LSdescStatistics"]] == "LSdescRange") {
       p <- .dotPlotVisualizeRange(data, p, dotsize, yLimits, colors)
-    } else if (options[["LSdescS"]] == "LSdescQR") {
+    } else if (options[["LSdescStatistics"]] == "LSdescQR") {
       p <- .dotPlotVisualizeQuartiles(data, p, dotsize, labelSize, yLimits, xLimits, xBreaks, labelText = gettext("2nd quar. / \n Median"),
                                       quartile = 2, labelsInCorner = TRUE, color = colors[1])
       p <- .dotPlotVisualizeQuartiles(data, p, dotsize, labelSize, yLimits, xLimits, xBreaks, labelText = gettext("1st quar."), quartile = 1,
@@ -889,7 +892,7 @@ LSTdescriptives <- function(jaspResults, dataset, options, state = NULL) {
       p <- .dotPlotVisualizeQuartiles(data, p, dotsize, labelSize, yLimits, xLimits, xBreaks, labelText = gettext("3rd quar."), quartile = 3,
                                       labelsInCorner = TRUE, color = colors[5])
       p <- .dotPlotIQRLine(data, p, yLimits, labelSize, colors)
-    } else if (options[["LSdescS"]] == "LSdescSD") {
+    } else if (options[["LSdescStatistics"]] == "LSdescSD") {
       p <- .drawSpreadVisualization(jaspResults, options, data, p, yMax = max(yLimits), xLimits, xBreaks, labelSize, colors = colors)
     }
   }

--- a/R/LSTdescriptives.R
+++ b/R/LSTdescriptives.R
@@ -457,17 +457,27 @@ LSTdescriptives <- function(jaspResults, dataset, options, state = NULL) {
   n <- options[["lstDescSampleN"]]
   if (options[["lstDescSampleDistType"]] == "lstSampleDistDiscrete") {
     if (options[["LSdescDiscreteDistributions"]] == "binomialDist") {
-      data <- rbinom(n, 10, prob = .5)
+      k <- options[["binomialDistributionNumberOfTrials"]]
+      p <- options[["binomialDistributionSuccessProbability"]]
+      data <- rbinom(n, k, prob = p)
     } else if (options[["LSdescDiscreteDistributions"]] == "poissonDist") {
-      data <- rpois(n, 1)
+      lambda <- options[["poissonDistributionLambda"]]
+      data <- rpois(n, lambda)
     }
   } else if (options[["lstDescSampleDistType"]] == "lstSampleDistCont") {
     if (options[["LSdescContinuousDistributions"]] == "skewedNormal") {
-      data <- sn::rsn(n, alpha = 100)
+      xi <- options[["skewedNormalDistributionLocation"]]
+      omega <- options[["skewedNormalDistributionScale"]]
+      alpha <- options[["skewedNormalDistributionShape"]]
+      data <- sn::rsn(n, alpha = alpha, xi = xi, omega = omega)
     } else if (options[["LSdescContinuousDistributions"]] == "uniform") {
-      data <- runif(n = n, min = 0, max = 5)
+      min <- options[["uniformDistributionLowerBound"]]
+      max <- options[["uniformDistributionUpperBound"]]
+      data <- runif(n = n, min = min, max = max)
     } else if (options[["LSdescContinuousDistributions"]] == "normal") {
-      data <- rnorm(n, 0, 10)
+      mu <- options[["normalDistributionMean"]]
+      sigma <- options[["normalDistributionStdDev"]]
+      data <- rnorm(n, mu, sigma)
     }
   }
   df <- data.frame(x = data)

--- a/inst/Description.qml
+++ b/inst/Description.qml
@@ -15,19 +15,19 @@ Description
 	license:		"GPL (>= 2)"
 	
 	
-	// Analysis
-	// {
-	// 	title:	qsTr("Normal Distribution")
-	// 	qml:	"LSTnormDist.qml"
-	// 	func:	"LSTnormDist"
-	// }
+	Analysis
+	{
+		title:	qsTr("Normal Distribution")
+		qml:	"LSTnormDist.qml"
+		func:	"LSTnormDist"
+	}
 	
-	// Analysis
-	// {
-	// 	title:	qsTr("Binomial Distribution")
-	// 	qml:	"LSTbinomDist.qml"
-	// 	func:	"LSTbinomDist"
-	// }
+	Analysis
+	{
+		title:	qsTr("Binomial Distribution")
+		qml:	"LSTbinomDist.qml"
+		func:	"LSTbinomDist"
+	}
 
 	Analysis
 	{

--- a/inst/Description.qml
+++ b/inst/Description.qml
@@ -15,19 +15,19 @@ Description
 	license:		"GPL (>= 2)"
 	
 	
-	Analysis
-	{
-		title:	qsTr("Normal Distribution")
-		qml:	"LSTnormDist.qml"
-		func:	"LSTnormDist"
-	}
+	// Analysis
+	// {
+	// 	title:	qsTr("Normal Distribution")
+	// 	qml:	"LSTnormDist.qml"
+	// 	func:	"LSTnormDist"
+	// }
 	
-	Analysis
-	{
-		title:	qsTr("Binomial Distribution")
-		qml:	"LSTbinomDist.qml"
-		func:	"LSTbinomDist"
-	}
+	// Analysis
+	// {
+	// 	title:	qsTr("Binomial Distribution")
+	// 	qml:	"LSTbinomDist.qml"
+	// 	func:	"LSTbinomDist"
+	// }
 
 	Analysis
 	{

--- a/inst/qml/LSTcentralLimitTheorem.qml
+++ b/inst/qml/LSTcentralLimitTheorem.qml
@@ -27,7 +27,7 @@ Form
 	
 	Section
 	{
-		title: qsTr("Parent Distribution")
+		title: qsTr("Parent distribution")
 		expanded: true
 
 		Group
@@ -36,7 +36,7 @@ Form
 			DropDown
 			{
 				name:				"cltParentDistribution"
-				label:				qsTr("Parent Distribution")
+				label:				qsTr("Parent distribution")
 				indexDefaultValue:	0
 				id:					cltParentDistribution
 				values:
@@ -76,7 +76,7 @@ Form
 			DoubleField
 			{
 				name:			"cltStdDev"
-				label:			qsTr("Std. Dev.")
+				label:			qsTr("Std. dev.")
 				fieldWidth:		60
 				defaultValue:	1
 				decimals:		2
@@ -98,7 +98,7 @@ Form
 			DropDown
 			{
 				name:				"cltSkewDirection"
-				label:				qsTr("Skew Direction")
+				label:				qsTr("Skew direction")
 				indexDefaultValue:	0
 				visible:			cltParentDistribution.currentValue == "skewed"
 				id:					cltSkewDirection
@@ -112,7 +112,7 @@ Form
 			DropDown
 			{
 				name:				"cltSkewIntensity"
-				label:				qsTr("Skew Intensity")
+				label:				qsTr("Skew intensity")
 				indexDefaultValue:	0
 				visible:			cltParentDistribution.currentValue == "skewed"
 				id:					cltSkewIntensity
@@ -134,7 +134,7 @@ Form
 	
 	Section
 	{
-		title: qsTr("Sample Options")
+		title: qsTr("Sample options")
 	
 		Group
 		{
@@ -205,10 +205,10 @@ Form
 				indexDefaultValue:	0
 				values:
 				[
-					{ label: qsTr("First"),		value: "first"},
+					{ label: qsTr("First"),		value: "first"	},
 					{ label: qsTr("Last"),		value: "last"	},
-					{ label: qsTr("Range"),			value: "range"		},
-					{ label: qsTr("All"),			value: "all"		}
+					{ label: qsTr("Range"),		value: "range"	},
+					{ label: qsTr("All"),		value: "all"	}
 				]
 			}
 
@@ -252,7 +252,7 @@ Form
 	
 	Section
 	{
-		title: qsTr("Sampling Distribution Options")
+		title: qsTr("Sampling distribution options")
 	
 		CheckBox
 		{
@@ -285,7 +285,7 @@ Form
 	
 	Section
 	{
-		title: qsTr("Plot Options")
+		title: qsTr("Plot options")
 	
 		DropDown
 		{

--- a/inst/qml/LSTconfidenceIntervals.qml
+++ b/inst/qml/LSTconfidenceIntervals.qml
@@ -153,11 +153,70 @@ Form
 				}
 			}
 		}
+
 		CheckBox
 		{
 			name:	"dataPlot"
 			label:	qsTr("Data distribution plots")
+
+			Group
+			{
+			
+				columns:	3
+			
+				DropDown
+				{
+					name:				"ciSampleShowType"
+					label:				qsTr("Show samples")
+					id:					ciSampleShowType
+					indexDefaultValue:	0
+					values:
+					[
+						{ label: qsTr("First"),		value: "first"	},
+						{ label: qsTr("Last"),		value: "last"	},
+						{ label: qsTr("Range"),		value: "range"	},
+						{ label: qsTr("All"),		value: "all"	}
+					]
+				}
+
+				IntegerField
+				{
+					name:			"ciFirstOrLastSamples"
+					label:			""
+					fieldWidth:		60
+					defaultValue:	7
+					visible:		ciSampleShowType.currentValue == "first" | ciSampleShowType.currentValue == "last"
+					max:			ciSampleAmount.value
+					min:			1
+					}
+					
+					
+				IntegerField
+				{
+					name:			"ciFromSample"
+					id:				ciFromSample
+					label:			qsTr("From")
+					fieldWidth:		60
+					defaultValue:	1
+					visible:		ciSampleShowType.currentValue == "range"
+					min: 			1
+					max:			ciToSample.value
+				}
+					
+				IntegerField
+				{
+					name:			"ciToSample"
+					id:				ciToSample
+					label:			qsTr("To")
+					fieldWidth:		60
+					defaultValue:	7
+					visible:		ciSampleShowType.currentValue == "range"
+					max:			ciSampleAmount.value
+					min:			ciFromSample.value
+				}
+			}
 		}
+	
 		CheckBox
 		{
 			name: "convergencePlot"

--- a/inst/qml/LSTdecisionTree.qml
+++ b/inst/qml/LSTdecisionTree.qml
@@ -34,7 +34,7 @@ Form
 	{
 		name:									"nOutcomeVariables"
 		id:										nOutcomeVariables
-		title:			qsTr("How many outcome variables?")
+		title:									qsTr("How many outcome variables?")
 		
 		RadioButton
 		{

--- a/inst/qml/LSTdescriptives.qml
+++ b/inst/qml/LSTdescriptives.qml
@@ -232,7 +232,6 @@ Form
 		{
 			name: "LSdescExplanationC"
 			label: qsTr("Show explanation")
-			checked: true
 		}
 	}
 	
@@ -270,7 +269,6 @@ Form
 		{
 			name:		"LSdescExplanationS"
 			label:		qsTr("Show explanation")
-			checked:	true
 		}
 	}
 	
@@ -282,7 +280,6 @@ Form
 		{
 			name:		"LSdescHistBar"
 			label:		qsTr("Histogram / Barplot")
-			checked:	true
 		
 			RadioButtonGroup
 			{

--- a/inst/qml/LSTdescriptives.qml
+++ b/inst/qml/LSTdescriptives.qml
@@ -25,18 +25,18 @@ Form
 {
 	columns: 1
 	
-	DropDown
-	{
-		name: "LSdescCentralOrSpread"
-		label: qsTr("Statistics to explain")
-		indexDefaultValue: 0
-		id: lsDescCentralOrSpread
-		values:
-		[
-			{label: qsTr("Central tendency"), value: "LSdescCentralTendency"},
-			{label: qsTr("Spread"),	value: "LSdescSpread"}
-		]
-	}
+	// DropDown
+	// {
+	// 	name: "LSdescCentralOrSpread"
+	// 	label: qsTr("Statistics to explain")
+	// 	indexDefaultValue: 0
+	// 	id: lsDescCentralOrSpread
+	// 	values:
+	// 	[
+	// 		{label: qsTr("Central tendency"), value: "LSdescCentralTendency"},
+	// 		{label: qsTr("Spread"),	value: "LSdescSpread"}
+	// 	]
+	// }
 	
 	Section
 	{
@@ -190,87 +190,168 @@ Form
 				}
 			}
 		}
-	}
-	
-	Section
-	{
-		title: qsTr("Central tendency measures")
-		visible: lsDescCentralOrSpread.currentValue == "LSdescCentralTendency"
-		
+
+
 		RadioButtonGroup
 		{
-			title:									qsTr("Select central tendency measure")
-			name:									"LSdescCT"
+			title:									qsTr("Statistics to display")
+			name:									"LSdescStatistics"
+			columns:								3
 
-			RadioButton
-			{
-				name:								"LSdescMean"
-				label:								qsTr("Show mean")
-				checked:							true
+			Group
+			{	
+				title:								qsTr("Central tendency measures")
+
+				RadioButton
+				{
+					name:								"LSdescMean"
+					label:								qsTr("Show mean")
+					checked:							true
+				}
+				
+				RadioButton
+				{
+					name:								"LSdescMedian"
+					label:								qsTr("Show median")
+				}
+				
+				RadioButton
+				{
+				name:									"LSdescMode"
+				label:									qsTr("Show mode")
+				}
+				
+				RadioButton
+				{
+					name:								"LSdescMMM"
+					label:								qsTr("Compare all")
+				}
+
 			}
+
+			Group
+			{	
+				title:								qsTr("Spread measures")
+
+				RadioButton
+				{
+					name:		"LSdescRange"
+					label:		qsTr("Show range")
+					checked:	true
+				}
+				
+				RadioButton
+				{
+					name:	"LSdescQR"
+					label:	qsTr("Show quartiles")
+				}
 			
-			RadioButton
-			{
-				name:								"LSdescMedian"
-				label:								qsTr("Show median")
+				RadioButton
+				{
+					name:	"LSdescSD"
+					label:	qsTr("Show std. dev. and variance")
+				}
+
 			}
-			
-			RadioButton
+
+			Group
 			{
-			name:									"LSdescMode"
-			label:									qsTr("Show mode")
+				title:		" "
+				RadioButton
+				{
+					name:								"none"
+					label:								qsTr("None")
+					checked:							true
+				}
 			}
-			
-			RadioButton
+
+			CheckBox
 			{
-				name:								"LSdescMMM"
-				label:								qsTr("Compare all")
-			}
-		}
-		
-		CheckBox
-		{
-			name: "LSdescExplanationC"
-			label: qsTr("Show explanation")
+				name:		"LSdescExplanationS"
+				label:		qsTr("Show explanation")
+			}	
 		}
 	}
 	
-	Section
-	{
-		title: qsTr("Measures of spread")
-		visible: lsDescCentralOrSpread.currentValue == "LSdescSpread"
+	// Section
+	// {
+	// 	title: qsTr("Central tendency measures")
+	// 	visible: lsDescCentralOrSpread.currentValue == "LSdescCentralTendency"
 		
-		RadioButtonGroup
-		{
-			title:	qsTr("Select measure of spread")
-			name:	"LSdescS"
+	// 	RadioButtonGroup
+	// 	{
+	// 		title:									qsTr("Select central tendency measure")
+	// 		name:									"LSdescCT"
 
-			RadioButton
-			{
-				name:		"LSdescRange"
-				label:		qsTr("Range")
-				checked:	true
-			}
+	// 		RadioButton
+	// 		{
+	// 			name:								"LSdescMean"
+	// 			label:								qsTr("Show mean")
+	// 			checked:							true
+	// 		}
 			
-			RadioButton
-			{
-				name:	"LSdescQR"
-				label:	qsTr("Quartiles")
-			}
+	// 		RadioButton
+	// 		{
+	// 			name:								"LSdescMedian"
+	// 			label:								qsTr("Show median")
+	// 		}
+			
+	// 		RadioButton
+	// 		{
+	// 		name:									"LSdescMode"
+	// 		label:									qsTr("Show mode")
+	// 		}
+			
+	// 		RadioButton
+	// 		{
+	// 			name:								"LSdescMMM"
+	// 			label:								qsTr("Compare all")
+	// 		}
+	// 	}
 		
-			RadioButton
-			{
-				name:	"LSdescSD"
-				label:	qsTr("Std. dev. and variance")
-			}
-		}
+	// 	CheckBox
+	// 	{
+	// 		name: "LSdescExplanationC"
+	// 		label: qsTr("Show explanation")
+	// 	}
+	// }
+	
+	// Section
+	// {
+	// 	title: qsTr("Measures of spread")
+	// 	visible: lsDescCentralOrSpread.currentValue == "LSdescSpread"
 		
-		CheckBox
-		{
-			name:		"LSdescExplanationS"
-			label:		qsTr("Show explanation")
-		}
-	}
+	// 	RadioButtonGroup
+	// 	{
+	// 		title:	qsTr("Select measure of spread")
+	// 		name:	"LSdescS"
+
+	// 		RadioButton
+	// 		{
+	// 			name:		"LSdescRange"
+	// 			label:		qsTr("Range")
+	// 			checked:	true
+	// 		}
+			
+	// 		RadioButton
+	// 		{
+	// 			name:	"LSdescQR"
+	// 			label:	qsTr("Quartiles")
+	// 		}
+		
+	// 		RadioButton
+	// 		{
+	// 			name:	"LSdescSD"
+	// 			label:	qsTr("Std. dev. and variance")
+	// 		}
+	// 	}
+		
+	// 	CheckBox
+	// 	{
+	// 		name:		"LSdescExplanationS"
+	// 		label:		qsTr("Show explanation")
+	// 	}
+	// }
 	
 	Section
 	{

--- a/inst/qml/LSTdescriptives.qml
+++ b/inst/qml/LSTdescriptives.qml
@@ -25,19 +25,6 @@ Form
 {
 	columns: 1
 	
-	// DropDown
-	// {
-	// 	name: "LSdescCentralOrSpread"
-	// 	label: qsTr("Statistics to explain")
-	// 	indexDefaultValue: 0
-	// 	id: lsDescCentralOrSpread
-	// 	values:
-	// 	[
-	// 		{label: qsTr("Central tendency"), value: "LSdescCentralTendency"},
-	// 		{label: qsTr("Spread"),	value: "LSdescSpread"}
-	// 	]
-	// }
-	
 	Section
 	{
 		title: qsTr("Data options")
@@ -205,26 +192,25 @@ Form
 				RadioButton
 				{
 					name:								"LSdescMean"
-					label:								qsTr("Show mean")
-					checked:							true
+					label:								qsTr("Mean")
 				}
 				
 				RadioButton
 				{
 					name:								"LSdescMedian"
-					label:								qsTr("Show median")
+					label:								qsTr("Median")
 				}
 				
 				RadioButton
 				{
 				name:									"LSdescMode"
-				label:									qsTr("Show mode")
+				label:									qsTr("Mode")
 				}
 				
 				RadioButton
 				{
 					name:								"LSdescMMM"
-					label:								qsTr("Compare all")
+					label:								qsTr("All")
 				}
 
 			}
@@ -236,20 +222,19 @@ Form
 				RadioButton
 				{
 					name:							"LSdescRange"
-					label:							qsTr("Show range")
-					checked:						true
+					label:							qsTr("Range")
 				}
 				
 				RadioButton
 				{
 					name:							"LSdescQR"
-					label:							qsTr("Show quartiles")
+					label:							qsTr("Quartiles")
 				}
 			
 				RadioButton
 				{
 					name:							"LSdescSD"
-					label:							qsTr("Show std. dev. and variance")
+					label:							qsTr("Std. dev.")
 				}
 
 			}
@@ -273,86 +258,6 @@ Form
 			}	
 		}
 	}
-	
-	// Section
-	// {
-	// 	title: qsTr("Central tendency measures")
-	// 	visible: lsDescCentralOrSpread.currentValue == "LSdescCentralTendency"
-		
-	// 	RadioButtonGroup
-	// 	{
-	// 		title:									qsTr("Select central tendency measure")
-	// 		name:									"LSdescCT"
-
-	// 		RadioButton
-	// 		{
-	// 			name:								"LSdescMean"
-	// 			label:								qsTr("Show mean")
-	// 			checked:							true
-	// 		}
-			
-	// 		RadioButton
-	// 		{
-	// 			name:								"LSdescMedian"
-	// 			label:								qsTr("Show median")
-	// 		}
-			
-	// 		RadioButton
-	// 		{
-	// 		name:									"LSdescMode"
-	// 		label:									qsTr("Show mode")
-	// 		}
-			
-	// 		RadioButton
-	// 		{
-	// 			name:								"LSdescMMM"
-	// 			label:								qsTr("Compare all")
-	// 		}
-	// 	}
-		
-	// 	CheckBox
-	// 	{
-	// 		name: "LSdescExplanationC"
-	// 		label: qsTr("Show explanation")
-	// 	}
-	// }
-	
-	// Section
-	// {
-	// 	title: qsTr("Measures of spread")
-	// 	visible: lsDescCentralOrSpread.currentValue == "LSdescSpread"
-		
-	// 	RadioButtonGroup
-	// 	{
-	// 		title:	qsTr("Select measure of spread")
-	// 		name:	"LSdescS"
-
-	// 		RadioButton
-	// 		{
-	// 			name:		"LSdescRange"
-	// 			label:		qsTr("Range")
-	// 			checked:	true
-	// 		}
-			
-	// 		RadioButton
-	// 		{
-	// 			name:	"LSdescQR"
-	// 			label:	qsTr("Quartiles")
-	// 		}
-		
-	// 		RadioButton
-	// 		{
-	// 			name:	"LSdescSD"
-	// 			label:	qsTr("Std. dev. and variance")
-	// 		}
-	// 	}
-		
-	// 	CheckBox
-	// 	{
-	// 		name:		"LSdescExplanationS"
-	// 		label:		qsTr("Show explanation")
-	// 	}
-	// }
 	
 	Section
 	{
@@ -386,6 +291,36 @@ Form
 				name:		"LSdescHistBarRugs"
 				label:		qsTr("Display rug marks")
 				checked:	true
+			}
+
+			Group
+			{
+	
+				DropDown
+				{
+					name:				"descBinWidthType"
+					label:				qsTr("Histogram bin width type")
+					indexDefaultValue:	0
+					id:					binWidthType
+					values:
+					[
+					{label: qsTr("Sturges"),				value: "sturges"},
+					{label: qsTr("Scott"),					value: "scott"},
+					{label: qsTr("Doane"),					value: "doane"},
+					{label: qsTr("Freedman-Diaconis"),		value: "fd"	},
+					{label: qsTr("Manual"),					value: "manual"	}
+					]
+				}
+					
+				DoubleField
+				{
+					name:			"descNumberOfBins"
+					label:			qsTr("Number of bins")
+					defaultValue:	30
+					min:			3;
+					max:			10000;
+					enabled:		binWidthType.currentValue === "manual"
+				}
 			}
 		}
 		

--- a/inst/qml/LSTdescriptives.qml
+++ b/inst/qml/LSTdescriptives.qml
@@ -50,20 +50,20 @@ Form
 			name:		"lstDescDataType"
 			title:		qsTr("Data input type")
 			id:			lstDescDataType
+
+			RadioButton
+			{
+				value:		"dataSequence"
+				label:		qsTr("Enter sequence")
+				id:			dataTypeB
+				checked:	true
+			}
 			
 			RadioButton
 			{
 				value:		"dataRandom"
 				label:		qsTr("Random sample")
 				id:			dataTypeA
-				checked:	true
-			}
-			
-			RadioButton
-			{
-				value:		"dataSequence"
-				label:		qsTr("Enter sequence")
-				id:			dataTypeB
 			}
 			
 			RadioButton
@@ -295,7 +295,7 @@ Form
 				RadioButton
 				{
 					name:	"LSdescHistDens"
-					label:	qsTr("Show density (Histogram only)")
+					label:	qsTr("Show density (histogram only)")
 				}
 			}
 			

--- a/inst/qml/LSTdescriptives.qml
+++ b/inst/qml/LSTdescriptives.qml
@@ -33,7 +33,7 @@ Form
 		id: lsDescCentralOrSpread
 		values:
 		[
-			{label: qsTr("Central tendency"),		value: "LSdescCentralTendency"},
+			{label: qsTr("Central tendency"), value: "LSdescCentralTendency"},
 			{label: qsTr("Spread"),	value: "LSdescSpread"}
 		]
 	}
@@ -48,13 +48,13 @@ Form
 		{
 			columns:	3
 			name:		"lstDescDataType"
-			title:		qsTr("Data Input Type")
+			title:		qsTr("Data input type")
 			id:			lstDescDataType
 			
 			RadioButton
 			{
 				value:		"dataRandom"
-				label:		qsTr("Random Sample")
+				label:		qsTr("Random sample")
 				id:			dataTypeA
 				checked:	true
 			}
@@ -82,7 +82,7 @@ Form
 			DoubleField
 			{
 				name:			"lstDescSampleN"
-				visible:	dataTypeA.checked
+				visible:		dataTypeA.checked
 				label:			qsTr("Sample size")
 				fieldWidth:		60
 				defaultValue:	100
@@ -108,7 +108,7 @@ Form
 				columns:	3
 				name:		"lstDescSampleDistType"
 				visible:	dataTypeA.checked
-				title:		qsTr("Distribution Type")
+				title:		qsTr("Distribution type")
 				id:			distributionType
 		
 				RadioButton
@@ -159,10 +159,10 @@ Form
 		
 		TextArea
 		{
-			title:		qsTr("Comma-separated Sequence of Observations")
+			title:		qsTr("Comma-separated sequence of observations")
 			visible:	dataTypeB.checked
 			height:		100
-			name:     "lstDescDataSequenceInput"
+			name:		"lstDescDataSequenceInput"
 			textType:	JASP.TextTypeSource
 			separators:	[",",";","\n"]
 		}
@@ -194,37 +194,37 @@ Form
 	
 	Section
 	{
-		title: qsTr("Central Tendency Measures")
+		title: qsTr("Central tendency measures")
 		visible: lsDescCentralOrSpread.currentValue == "LSdescCentralTendency"
 		
 		RadioButtonGroup
 		{
-			title:                                  qsTr("Select Central Tendency Measure")
-			name:                                   "LSdescCT"
+			title:									qsTr("Select central tendency measure")
+			name:									"LSdescCT"
 
 			RadioButton
 			{
-				name:                               "LSdescMean"
-				label:                              qsTr("Show Mean")
-				checked:                            true
+				name:								"LSdescMean"
+				label:								qsTr("Show mean")
+				checked:							true
 			}
 			
 			RadioButton
 			{
-				name:                               "LSdescMedian"
-				label:                              qsTr("Show Median")
+				name:								"LSdescMedian"
+				label:								qsTr("Show median")
 			}
 			
 			RadioButton
 			{
-			name:                               "LSdescMode"
-			label:                              qsTr("Show Mode")
+			name:									"LSdescMode"
+			label:									qsTr("Show mode")
 			}
 			
 			RadioButton
 			{
-				name:                               "LSdescMMM"
-				label:                              qsTr("Compare All")
+				name:								"LSdescMMM"
+				label:								qsTr("Compare all")
 			}
 		}
 		

--- a/inst/qml/LSTdescriptives.qml
+++ b/inst/qml/LSTdescriptives.qml
@@ -235,21 +235,21 @@ Form
 
 				RadioButton
 				{
-					name:		"LSdescRange"
-					label:		qsTr("Show range")
-					checked:	true
+					name:							"LSdescRange"
+					label:							qsTr("Show range")
+					checked:						true
 				}
 				
 				RadioButton
 				{
-					name:	"LSdescQR"
-					label:	qsTr("Show quartiles")
+					name:							"LSdescQR"
+					label:							qsTr("Show quartiles")
 				}
 			
 				RadioButton
 				{
-					name:	"LSdescSD"
-					label:	qsTr("Show std. dev. and variance")
+					name:							"LSdescSD"
+					label:							qsTr("Show std. dev. and variance")
 				}
 
 			}
@@ -257,17 +257,18 @@ Form
 			Group
 			{
 				title:		" "
+
 				RadioButton
 				{
-					name:								"none"
-					label:								qsTr("None")
-					checked:							true
+					name:							"none"
+					label:							qsTr("None")
+					checked:						true
 				}
 			}
 
 			CheckBox
 			{
-				name:		"LSdescExplanationS"
+				name:		"LSdescExplanation"
 				label:		qsTr("Show explanation")
 			}	
 		}

--- a/inst/qml/LSTdescriptives.qml
+++ b/inst/qml/LSTdescriptives.qml
@@ -353,4 +353,126 @@ Form
 			]
 		}
 	}
+
+	Section
+	{
+		title:		qsTr("Distribution options")
+		visible:	dataTypeA.checked
+
+		Group
+		{
+			title:		qsTr("Binomial distribution parameters")
+			visible:	lsDescDiscreteDistributions.currentValue == "binomialDist" && distTypeDisc.checked
+
+			DoubleField
+			{
+				name:			"binomialDistributionSuccessProbability"
+				label:			qsTr("Probability of success (p)")
+				defaultValue:	.5
+				min:			0
+				max:			1
+			}
+
+			DoubleField
+			{
+				name:			"binomialDistributionNumberOfTrials"
+				label:			qsTr("Number of trials (k)")
+				defaultValue:	10
+				min:			1
+			}
+		}
+
+		Group
+		{
+			title:		qsTr("Poisson distribution parameters")
+			visible:	lsDescDiscreteDistributions.currentValue == "poissonDist" && distTypeDisc.checked
+
+			DoubleField
+			{
+				name:			"poissonDistributionLambda"
+				label:			qsTr("Rate (λ)")
+				defaultValue:	1
+				min:			0
+			}
+		}
+
+		Group
+		{
+			title:		qsTr("Skewed normal distribution parameters")
+			visible:	lsDescContinuousDistributions.currentValue == "skewedNormal" && distTypeCont.checked
+
+			DoubleField
+			{
+				name:			"skewedNormalDistributionLocation"
+				label:			qsTr("Location (ξ)")
+				defaultValue:	0
+				negativeValues:	true
+			}
+
+			DoubleField
+			{
+				name:			"skewedNormalDistributionScale"
+				label:			qsTr("Scale (ω)")
+				defaultValue:	1
+				min:			0
+			}
+
+			DoubleField
+			{
+				name:			"skewedNormalDistributionShape"
+				label:			qsTr("Shape (α)")
+				defaultValue:	100
+				negativeValues:	true
+			}
+		}
+
+		Group
+		{
+			title:		qsTr("Uniform distribution parameters")
+			visible:	lsDescContinuousDistributions.currentValue == "uniform" && distTypeCont.checked
+
+			DoubleField
+			{
+				name:			"uniformDistributionLowerBound"
+				label:			qsTr("Lower bound")
+				defaultValue:	0
+				id:				uniformDistributionLowerBound
+				max: 			parseFloat(uniformDistributionUpperBound.value)
+				negativeValues:	true
+			}
+
+			DoubleField
+			{
+				name:			"uniformDistributionUpperBound"
+				label:			qsTr("Upper bound")
+				defaultValue:	5
+				id:				uniformDistributionUpperBound
+				min: 			parseFloat(uniformDistributionLowerBound.value)
+				negativeValues:	true
+			}
+
+		}
+
+		Group
+		{
+			title:		qsTr("Normal distribution parameters")
+			visible:	lsDescContinuousDistributions.currentValue == "normal" && distTypeCont.checked
+
+			DoubleField
+			{
+				name:			"normalDistributionMean"
+				label:			qsTr("Mean (μ)")
+				defaultValue:	0
+				negativeValues:	true
+			}
+
+			DoubleField
+			{
+				name:			"normalDistributionStdDev"
+				label:			qsTr("Std. dev. (σ)")
+				defaultValue:	10
+				min:			0
+			}
+		}
+	}
 }

--- a/inst/qml/LSTsampleVariability.qml
+++ b/inst/qml/LSTsampleVariability.qml
@@ -38,7 +38,7 @@ Form
 			{
 				columns:	2
 				name:		"svParentSizeType"
-				title:		qsTr("Parent Distribution Size")
+				title:		qsTr("Parent distribution size")
 				id:			svParentSizeType
 			
 				RadioButton
@@ -71,7 +71,7 @@ Form
 			DropDown
 			{
 				name:				"cltParentDistribution"
-				label:				qsTr("Parent Distribution Shape")
+				label:				qsTr("Parent distribution shape")
 				indexDefaultValue:	0
 				id:					cltParentDistribution
 				values:
@@ -114,7 +114,7 @@ Form
 			DoubleField
 			{
 				name:			"cltStdDev"
-				label:			qsTr("Std. Dev.")
+				label:			qsTr("Std. dev.")
 				fieldWidth:		60
 				defaultValue:	1
 				decimals:		2
@@ -136,7 +136,7 @@ Form
 			DropDown
 			{
 				name:				"cltSkewDirection"
-				label:				qsTr("Skew Direction")
+				label:				qsTr("Skew direction")
 				indexDefaultValue:	0
 				visible:			cltParentDistribution.currentValue == "skewed"
 				id:					cltSkewDirection
@@ -150,7 +150,7 @@ Form
 			DropDown
 			{
 				name:				"cltSkewIntensity"
-				label:				qsTr("Skew Intensity")
+				label:				qsTr("Skew intensity")
 				indexDefaultValue:	0
 				visible:			cltParentDistribution.currentValue == "skewed"
 				id:					cltSkewIntensity
@@ -310,7 +310,7 @@ Form
 				{
 					name:			"svToSample"
 					id:				svToSample
-					label:			qsTr("To")
+					label:			qsTr("to")
 					fieldWidth:		60
 					defaultValue:	7
 					visible:		svSampleShowType.currentValue == "range"

--- a/inst/qml/LSTstandardError.qml
+++ b/inst/qml/LSTstandardError.qml
@@ -36,7 +36,7 @@ Form
 			DropDown
 			{
 				name:				"cltParentDistribution"
-				label:				qsTr("Parent Distribution")
+				label:				qsTr("Parent distribution")
 				indexDefaultValue:	0
 				id:					cltParentDistribution
 				values:
@@ -76,7 +76,7 @@ Form
 			DoubleField
 			{
 				name:			"cltStdDev"
-				label:			qsTr("Std. Dev.")
+				label:			qsTr("Std. dev.")
 				fieldWidth:		60
 				defaultValue:	1
 				decimals:		2
@@ -98,7 +98,7 @@ Form
 			DropDown
 			{
 				name:				"cltSkewDirection"
-				label:				qsTr("Skew Direction")
+				label:				qsTr("Skew direction")
 				indexDefaultValue:	0
 				visible:			cltParentDistribution.currentValue == "skewed"
 				id:					cltSkewDirection
@@ -112,7 +112,7 @@ Form
 			DropDown
 			{
 				name:				"cltSkewIntensity"
-				label:				qsTr("Skew Intensity")
+				label:				qsTr("Skew intensity")
 				indexDefaultValue:	0
 				visible:			cltParentDistribution.currentValue == "skewed"
 				id:					cltSkewIntensity
@@ -142,7 +142,7 @@ Form
 	
 	Section
 	{
-		title: qsTr("Sample Options")
+		title: qsTr("Sample options")
 	
 		Group
 		{
@@ -213,10 +213,10 @@ Form
 				indexDefaultValue:	0
 				values:
 				[
-					{ label: qsTr("First"),		value: "first"},
+					{ label: qsTr("First"),		value: "first"	},
 					{ label: qsTr("Last"),		value: "last"	},
-					{ label: qsTr("Range"),			value: "range"		},
-					{ label: qsTr("All"),			value: "all"		}
+					{ label: qsTr("Range"),		value: "range"	},
+					{ label: qsTr("All"),		value: "all"	}
 				]
 			}
 
@@ -248,7 +248,7 @@ Form
 			{
 				name:			"cltToSample"
 				id:				cltToSample
-				label:			qsTr("To")
+				label:			qsTr("to")
 				fieldWidth:		60
 				defaultValue:	7
 				visible:		cltSampleShowType.currentValue == "range"
@@ -260,7 +260,7 @@ Form
 	
 	Section
 	{
-		title: qsTr("Sampling Distribution Options")
+		title: qsTr("Sampling distribution options")
 	
 		CheckBox
 		{

--- a/inst/qml/LSeffectSizes.qml
+++ b/inst/qml/LSeffectSizes.qml
@@ -28,7 +28,7 @@ Form {
 	{
 		name: 	"effectSize"
 		id:		effectSize
-		title:	qsTr("Effect Size")
+		title:	qsTr("Effect size")
   		
 		RadioButton
 		{
@@ -258,7 +258,7 @@ Form {
 
 		Group
 		{
-			title:			qsTr("Additional Statistics")
+			title:			qsTr("Additional statistics")
 			visible:		effectSize.value == "delta"
 
 			CheckBox
@@ -298,7 +298,7 @@ Form {
 
 		Group
 		{
-			title:			qsTr("Additional Statistics")
+			title:			qsTr("Additional statistics")
 			visible:		effectSize.value == "rho"
 				
 			CheckBox
@@ -311,34 +311,34 @@ Form {
 
 		Group
 		{
-			title:			qsTr("Additional Statistics")
+			title:			qsTr("Additional statistics")
 			visible:		effectSize.value == "phi"
 				
 			CheckBox
 			{
 				name:			"phiOR"
-				label:			qsTr("Odds Ratio")
+				label:			qsTr("Odds ratio")
 				checked:		false
 			}
 
 			CheckBox
 			{
 				name:			"phiRR"
-				label:			qsTr("Risk Ratio")
+				label:			qsTr("Risk ratio")
 				checked:		false
 			}
 
 			CheckBox
 			{
 				name:			"phiRD"
-				label:			qsTr("Risk Difference")
+				label:			qsTr("Risk difference")
 				checked:		false
 			}
 		}
 
 		Group
 		{
-			title:			qsTr("Plot Options")
+			title:			qsTr("Plot options")
 				
 			CheckBox
 			{


### PR DESCRIPTION
- CI: Made table under tree plot display only the CIs that are also plotted
- CI: Added option to select which samples are displayed (first x, last x, range, all)

Branch based on https://github.com/jasp-stats/jaspLearnStats/pull/38, so this PR should be merged after the previous one