### PR TITLE
Disable the explanations

### DIFF
--- a/R/LSTdecisionTree.R
+++ b/R/LSTdecisionTree.R
@@ -207,6 +207,7 @@ LSTdecisionTree <- function(jaspResults, dataset = NULL, options) {
   
   jaspResults[["DecisionTree"]] <- createJaspContainer("")
   jaspResults[["DecisionTree"]][["Heading"]] <- plot1
+  # jaspResults[["DecisionTree"]][["Text"]] <- createJaspHtml("placeholder", "p") #TODO: Write an informative explanation for each test and where to find it in JASP (maybe even create a link if possible).
   
   # create decision tree plot
   if (options[["displayFullTree"]]) {

--- a/R/LSTdecisionTree.R
+++ b/R/LSTdecisionTree.R
@@ -207,7 +207,6 @@ LSTdecisionTree <- function(jaspResults, dataset = NULL, options) {
   
   jaspResults[["DecisionTree"]] <- createJaspContainer("")
   jaspResults[["DecisionTree"]][["Heading"]] <- plot1
-  jaspResults[["DecisionTree"]][["Text"]] <- createJaspHtml("Some explanation and maybe a link to the test?", "p")
   
   # create decision tree plot
   if (options[["displayFullTree"]]) {

--- a/inst/qml/LSTPValues.qml
+++ b/inst/qml/LSTPValues.qml
@@ -294,6 +294,13 @@ Form
 	Section
 	{
 		title:	qsTr("Options")
-		CheckBox	{	name: "introText"; label:	qsTr("Introductory text")	}
+		
+		CheckBox	
+		{	
+			name: "introText" 
+			label:	qsTr("Introductory text")
+			checked:	false
+			enabled:	false
+		}
 	}
 }

--- a/inst/qml/LSTcentralLimitTheorem.qml
+++ b/inst/qml/LSTcentralLimitTheorem.qml
@@ -58,7 +58,8 @@ Form
 			{
 				name:		"parentExplain"
 				label:		qsTr("Show explanatory text")
-				checked:	true
+				checked:	false
+				enabled:	false
 			}
 		}
 		
@@ -179,7 +180,8 @@ Form
 			{
 				name:		"samplesExplain"
 				label:		qsTr("Show explanatory text")
-				checked:	true
+				checked:	false
+				enabled:	false
 			}
 		
 			DoubleField
@@ -279,7 +281,8 @@ Form
 			{
 				name:		"samplingDistExplain"
 				label:		qsTr("Show explanatory text")
-				checked:	true
+				checked:	false
+				enabled:	false
 			}
 	}
 	

--- a/inst/qml/LSTdescriptives.qml
+++ b/inst/qml/LSTdescriptives.qml
@@ -255,6 +255,8 @@ Form
 			{
 				name:		"LSdescExplanation"
 				label:		qsTr("Show explanation")
+				checked:	false
+				enabled:	false
 			}	
 		}
 	}

--- a/inst/qml/LSTsampleVariability.qml
+++ b/inst/qml/LSTsampleVariability.qml
@@ -94,7 +94,8 @@ Form
 			{
 				name:		"parentExplain"
 				label:		qsTr("Show explanatory text")
-				checked:	true
+				checked:	false
+				enabled:	false
 			}
 		}
 		
@@ -249,7 +250,8 @@ Form
 			{
 				name:		"samplesExplain"
 				label:		qsTr("Show explanatory text")
-				checked:	true
+				checked:	false
+				enabled:	false
 			}
 		
 			DoubleField

--- a/inst/qml/LSTstandardError.qml
+++ b/inst/qml/LSTstandardError.qml
@@ -58,7 +58,8 @@ Form
 			{
 				name:		"parentExplain"
 				label:		qsTr("Show explanatory text")
-				checked:	true
+				checked:	false
+				enabled:	false
 			}
 		}
 		
@@ -187,7 +188,8 @@ Form
 			{
 				name:		"samplesExplain"
 				label:		qsTr("Show explanatory text")
-				checked:	true
+				checked:	false
+				enabled:	false
 			}
 		
 			DoubleField
@@ -287,7 +289,8 @@ Form
 		{
 			name:		"samplingDistExplain"
 			label:		qsTr("Show explanatory text")
-			checked:	true
+			checked:	false
+			enabled:	false
 		}
 	}
 	


### PR DESCRIPTION
Removing the explanations for now by disabling the checkboxes. They are default off and cannot be clicked. I thought it was still okay to keep them visible, so people see this feature will come?