### PR TITLE
Replace mainWindow by dataSetInfo

### DIFF
--- a/inst/qml/LSTdescriptives.qml
+++ b/inst/qml/LSTdescriptives.qml
@@ -58,7 +58,7 @@ Form
 				value:		"dataVariable"
 				label:		qsTr("Select variable")
 				id:			dataTypeC
-				enabled:	mainWindow.dataAvailable
+				enabled:	dataSetInfo.dataAvailable
 			}
 		}
 		


### PR DESCRIPTION
QML analysis files should not use objects that are not defined outside the QMLComponents library.

Cf jasp-stats/jasp-desktop#5281